### PR TITLE
chore: Add publish config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   publish:
     name: Publish
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     if: |
       contains(github.event.head_commit.message, 'meta(changelog)') 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -26,5 +26,9 @@
   },
   "devDependencies": {
     "@debugids/common": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,5 +17,9 @@
   },
   "dependencies": {
     "@debugids/common": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,5 +21,9 @@
   },
   "scripts": {
     "build": "rollup --config rollup.config.mjs"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -25,5 +25,9 @@
   },
   "dependencies": {
     "@debugids/common": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -25,5 +25,9 @@
   },
   "dependencies": {
     "@debugids/common": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/parcel/package.json
+++ b/packages/parcel/package.json
@@ -29,5 +29,9 @@
   "dependencies": {
     "@parcel/plugin": "^2.0.0",
     "@debugids/common": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -25,5 +25,9 @@
   },
   "dependencies": {
     "@debugids/rollup": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -25,5 +25,9 @@
   },
   "dependencies": {
     "@debugids/common": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -25,5 +25,9 @@
   },
   "dependencies": {
     "@debugids/webpack": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -25,5 +25,9 @@
   },
   "dependencies": {
     "@debugids/rollup": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -25,5 +25,9 @@
   },
   "dependencies": {
     "@debugids/common": "0.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
Add `id-token` to GHA and `provenance: true` to enable provenance publishing

Add `access` public so that scoped packages can publish properly.