### PR TITLE
chore: Add content write permission

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
     name: Publish
     permissions:
       id-token: write
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: |
       contains(github.event.head_commit.message, 'meta(changelog)') 


### PR DESCRIPTION
Add permissions to get GHA releases working properly.