### PR TITLE
feat: Document Rolldown native support

### DIFF
--- a/packages/rolldown/README.md
+++ b/packages/rolldown/README.md
@@ -4,6 +4,24 @@
 
 Injects Debug IDs into source and sourcemaps when using Rolldown.
 
+Rolldown v0.14.0 and later support debug IDs natively without any plugins:
+
+`rolldown.config.mjs`
+
+```ts
+export default {
+  input: "./src/main.js",
+  output: {
+    dir: "dist",
+    format: "esm",
+    sourcemap: true,
+    sourcemapDebugIds: true,
+  },
+};
+```
+
+For older versions of Rolldown, you can use this plugin to inject debug IDs:
+
 `rolldown.config.mjs`
 
 ```ts


### PR DESCRIPTION
Closes #36

Rolldown includes debug ID support in v0.14.0