### PR TITLE
feat: Document native Rspack support

### DIFF
--- a/packages/rspack/README.md
+++ b/packages/rspack/README.md
@@ -4,6 +4,23 @@
 
 Injects Debug IDs into source and sourcemaps when using Rspack.
 
+Rspack v1.2.0 and later support debug IDs natively without any plugins. Just add `-debugids` to the end of any devtool option:
+
+`rspack.config.mjs`
+```ts
+export default {
+  entry: "./src/main.js",
+  mode: "production",
+  devtool: "source-map-debugids",
+  output: {
+    filename: "main.js",
+    path: "./dist",
+  },
+};
+```
+
+For older versions of webpack, you can use this plugin to inject debug IDs:
+
 `rspack.config.mjs`
 
 ```ts


### PR DESCRIPTION
At some point we might want to publish releases to npm so the all the readme's get updated detailing bundlers that support Debug IDs natively.